### PR TITLE
v0.6.0 security hardening: injection fixes, SSL, serialize→JSON migration

### DIFF
--- a/modules/channelModeration/module.php
+++ b/modules/channelModeration/module.php
@@ -20,7 +20,7 @@ function channelMod($data) {
     $target       = (isset($argparts[0]) && $argparts[0] !== '') ? $argparts[0] : '';
     $duration_str = null;
     $reason_start = 1;
-    if (isset($argparts[1]) && preg_match('/^\d+[mhdwMHDW]$/', $argparts[1])) {
+    if (isset($argparts[1]) && preg_match('/^(\d+[mhdwMHDW]|0|perm(anent)?)$/i', $argparts[1])) {
         $duration_str = $argparts[1];
         $reason_start = 2;
     }
@@ -146,7 +146,11 @@ function channelModeration_applyQuiet($by, $target, $duration_str, $reason) {
         return;
     }
 
-    $secs     = channelModeration_parseDuration($duration_str);
+    $secs = channelModeration_parseDuration($duration_str);
+    if ($secs === false) {
+        fputs($socket, "NOTICE {$by} :Duration too large — use 'perm' or '0' for a permanent action.\r\n");
+        return;
+    }
     $dur_text = $secs !== null ? channelModeration_formatDuration($secs) : 'permanent';
 
     $existing = channelModeration_getActiveAction($target, 'quiet');
@@ -201,7 +205,15 @@ function channelModeration_applyBan($by, $target, $duration_str, $reason, $kick_
     }
 
     // Redirect bans are always permanent
-    $secs     = $redirect ? null : channelModeration_parseDuration($duration_str);
+    if (!$redirect) {
+        $secs = channelModeration_parseDuration($duration_str);
+        if ($secs === false) {
+            fputs($socket, "NOTICE {$by} :Duration too large — use 'perm' or '0' for a permanent action.\r\n");
+            return;
+        }
+    } else {
+        $secs = null;
+    }
     $dur_text = $secs !== null ? channelModeration_formatDuration($secs) : 'permanent';
     $type     = $redirect ? 'redirect' : 'ban';
 
@@ -404,17 +416,16 @@ function channelModeration_getMask($target_nick, $redirect = false, $requestedBy
 }
 
 function channelModeration_parseDuration($str) {
-    if (empty($str) || $str === '0') return null;
+    if (empty($str)) return null;
     $str = strtolower(trim($str));
+    if ($str === '0' || $str === 'perm' || $str === 'permanent') return null;
     if (!preg_match('/^(\d+)([mhdw])$/', $str, $m)) return null;
-    $n = (int)$m[1];
-    switch ($m[2]) {
-        case 'm': return $n * 60;
-        case 'h': return $n * 3600;
-        case 'd': return $n * 86400;
-        case 'w': return $n * 604800;
-    }
-    return null;
+    $n    = (int)$m[1];
+    $mult = ['m' => 60, 'h' => 3600, 'd' => 86400, 'w' => 604800];
+    $secs = $n * $mult[$m[2]];
+    $max  = mktime(0, 0, 0, 12, 31, 9999) - time();
+    if ($secs > $max) return false;
+    return $secs;
 }
 
 function channelModeration_formatDuration($secs) {

--- a/modules/doActionFromCommand/module.php
+++ b/modules/doActionFromCommand/module.php
@@ -11,7 +11,8 @@ function doActionFromCommand($ircdata) {
     switch($options['action']) {
         case "%COMMANDARGS%":
             if($ircdata['commandargs'] != "") {
-                fputs($socket, "PRIVMSG ".$ircdata['location']." :\001ACTION ".$ircdata['commandargs']."\001\n");
+                $action = str_replace(["\r", "\n", "\0"], '', $ircdata['commandargs']);
+                fputs($socket, "PRIVMSG ".$ircdata['location']." :\001ACTION ".$action."\001\n");
             }
             break;
         case "%USERNICKNAME%":

--- a/modules/doBraveSearch/module.php
+++ b/modules/doBraveSearch/module.php
@@ -20,7 +20,7 @@ function doBraveSearch($data) {
             "X-Subscription-Token: " . $apiKey,
         ],
         CURLOPT_TIMEOUT => 10,
-        CURLOPT_SSL_VERIFYPEER => false,
+        CURLOPT_SSL_VERIFYPEER => true,
     ]);
     $response = curl_exec($ch);
     curl_close($ch);

--- a/modules/doMessageFromCommand/module.php
+++ b/modules/doMessageFromCommand/module.php
@@ -144,8 +144,10 @@ function replyRandomTagOtherUser($ircdata) {
 
 function isKnownUser($user) {
     global $config;
-    
+
     global $dbconnection;
+    $user = mysqli_real_escape_string($dbconnection, $user);
+    $user = str_replace(['%', '_'], ['\\%', '\\_'], $user);
     $query = "SELECT id FROM known_users WHERE nick_aliases LIKE '%".$user."%' LIMIT 1";
     $result = mysqli_query($dbconnection, $query);
     if(mysqli_num_rows($result) > 0) {

--- a/modules/gitGud/module.php
+++ b/modules/gitGud/module.php
@@ -4,6 +4,7 @@ function gitGud($data) {
 
     $usertogitgud = trim($data['commandargs']);
     $usertogitgud = mysqli_real_escape_string($dbconnection,$usertogitgud);
+    $usertogitgud = str_replace(['%', '_'], ['\\%', '\\_'], $usertogitgud);
     $query = "SELECT id FROM known_users WHERE nick_aliases LIKE '%$usertogitgud%'";
     $result = mysqli_query($dbconnection,$query);
     if(mysqli_num_rows($result) > 0) {

--- a/modules/quoteSystem/module.php
+++ b/modules/quoteSystem/module.php
@@ -4,18 +4,20 @@ function getQuote($data) {
 
     $search = $data['commandargs'];
     $search = mysqli_real_escape_string($dbconnection, $search);
-    
+
     //they are probably searching a specific id if search term is numeric
     if(is_numeric($search)) {
         $query = "SELECT * FROM quotes WHERE id = $search LIMIT 1";
     } elseif(strlen($search)>1) {
-        $query = "SELECT * FROM quotes WHERE quote LIKE '%$search%' ORDER BY rand() LIMIT 1";
+        $searchLike = str_replace(['%', '_'], ['\\%', '\\_'], $search);
+        $query = "SELECT * FROM quotes WHERE quote LIKE '%$searchLike%' ORDER BY rand() LIMIT 1";
     } else {
         $query = "SELECT * FROM quotes ORDER BY rand() LIMIT 1";
     }
 
     if(strlen($search) == 0) {
-        $notnick = $data['usernickname'];
+        $notnick = mysqli_real_escape_string($dbconnection, $data['usernickname']);
+        $notnick = str_replace(['%', '_'], ['\\%', '\\_'], $notnick);
         $query = "SELECT * FROM quotes WHERE submittedby NOT LIKE '%".$notnick."%' AND downvotes < 3 ORDER BY rand() LIMIT 1";
     }
 

--- a/modules/quoteSystem/module.php
+++ b/modules/quoteSystem/module.php
@@ -162,7 +162,7 @@ function upvoteQuote($data) {
             $id = $row['id'];
             $upvotes = $row['upvotes'];
             $voted_hostnames = $row['voted_hostnames'];
-            $votedhostnamesArray = unserialize($voted_hostnames);
+            $votedhostnamesArray = json_decode($voted_hostnames, true);
             if(empty($votedhostnamesArray)) {
                 $votedhostnamesArray = array();
             }
@@ -174,7 +174,7 @@ function upvoteQuote($data) {
                 } else {
                     array_push($votedhostnamesArray,$data['userhostname']);
                     $newupvotes = $upvotes + 1;
-                    $votedhostnames = serialize($votedhostnamesArray);
+                    $votedhostnames = json_encode($votedhostnamesArray);
                     $query = "UPDATE quotes SET upvotes = $newupvotes, voted_hostnames = '".$votedhostnames."' WHERE id = $id LIMIT 1";
                 }
             }
@@ -212,7 +212,7 @@ function downvoteQuote($data) {
             $id = $row['id'];
             $downvotes = $row['downvotes'];
             $voted_hostnames = $row['voted_hostnames'];
-            $votedhostnamesArray = unserialize($voted_hostnames);
+            $votedhostnamesArray = json_decode($voted_hostnames, true);
             if(empty($votedhostnamesArray)) {
                 $votedhostnamesArray = array();
             }
@@ -224,7 +224,7 @@ function downvoteQuote($data) {
                 } else {
                     array_push($votedhostnamesArray,$data['userhostname']);
                     $newdownvotes = $downvotes + 1;
-                    $votedhostnames = serialize($votedhostnamesArray);
+                    $votedhostnames = json_encode($votedhostnamesArray);
                     $query = "UPDATE quotes SET downvotes = $newdownvotes, voted_hostnames = '".$votedhostnames."' WHERE id = $id LIMIT 1";
                 }
             }

--- a/modules/seenInfo/module.php
+++ b/modules/seenInfo/module.php
@@ -4,6 +4,7 @@ function getSeenInfo($ircdata) {
 
     $who = trim($ircdata['commandargs']);
     $who = mysqli_real_escape_string($dbconnection, $who);
+    $who = str_replace(['%', '_'], ['\\%', '\\_'], $who);
     $query = "SELECT hostname,last_datatype,last_message,last_location,timestamp FROM known_users WHERE nick_aliases LIKE '%$who%' ORDER BY timestamp DESC LIMIT 1";
 
     $result = mysqli_query($dbconnection,$query);

--- a/modules/seenInfo/module.php
+++ b/modules/seenInfo/module.php
@@ -2,13 +2,19 @@
 function getSeenInfo($ircdata) {
     global $dbconnection;
 
-    $who = trim($ircdata['commandargs']);
-    $who = mysqli_real_escape_string($dbconnection, $who);
-    $who = str_replace(['%', '_'], ['\\%', '\\_'], $who);
-    $query = "SELECT hostname,last_datatype,last_message,last_location,timestamp FROM known_users WHERE nick_aliases LIKE '%$who%' ORDER BY timestamp DESC LIMIT 1";
+    $whoDisplay = trim($ircdata['commandargs']);
+
+    if (strlen($whoDisplay) < 2) {
+        sendPRIVMSG($ircdata['location'], "Please provide at least 2 characters to search.");
+        return true;
+    }
+
+    $whoQuery = mysqli_real_escape_string($dbconnection, $whoDisplay);
+    $whoQuery = str_replace(['%', '_'], ['\\%', '\\_'], $whoQuery);
+    $query = "SELECT hostname,last_datatype,last_message,last_location,timestamp FROM known_users WHERE nick_aliases LIKE '%$whoQuery%' ORDER BY timestamp DESC LIMIT 1";
 
     $result = mysqli_query($dbconnection,$query);
-                
+
     if(mysqli_num_rows($result) > 0) {
         if(mysqli_num_rows($result) > 1) {
             $message = "This is odd, it seems that your search returned multiple results. I can't show you seen data at this time - sorry!";
@@ -23,13 +29,13 @@ function getSeenInfo($ircdata) {
 
                 switch($lastdatatype) {
                     case "PRIVMSG":
-                        $message = "User '".$who."' was last seen on ".$timelastseen." using hostname '".$hostname."' saying \"".$lastmessage."\"";
+                        $message = "User '".$whoDisplay."' was last seen on ".$timelastseen." using hostname '".$hostname."' saying \"".$lastmessage."\"";
                         break;
                     case "QUIT":
-                        $message = "User '".$who."' was last seen on ".$timelastseen." using hostname '".$hostname."' quitting the channel.";
+                        $message = "User '".$whoDisplay."' was last seen on ".$timelastseen." using hostname '".$hostname."' quitting the channel.";
                         break;
                     case "JOIN":
-                        $message = "User '".$who."' was last seen on ".$timelastseen." using hostname '".$hostname."' joining the channel.";
+                        $message = "User '".$whoDisplay."' was last seen on ".$timelastseen." using hostname '".$hostname."' joining the channel.";
                         break;
                 }
             }

--- a/modules/seenInfo/module.php
+++ b/modules/seenInfo/module.php
@@ -29,13 +29,13 @@ function getSeenInfo($ircdata) {
 
                 switch($lastdatatype) {
                     case "PRIVMSG":
-                        $message = "User '".$whoDisplay."' was last seen on ".$timelastseen." using hostname '".$hostname."' saying \"".$lastmessage."\"";
+                        $message = "A user matching '".$whoDisplay."' was last seen on ".$timelastseen." using hostname '".$hostname."' saying \"".$lastmessage."\"";
                         break;
                     case "QUIT":
-                        $message = "User '".$whoDisplay."' was last seen on ".$timelastseen." using hostname '".$hostname."' quitting the channel.";
+                        $message = "A user matching '".$whoDisplay."' was last seen on ".$timelastseen." using hostname '".$hostname."' quitting the channel.";
                         break;
                     case "JOIN":
-                        $message = "User '".$whoDisplay."' was last seen on ".$timelastseen." using hostname '".$hostname."' joining the channel.";
+                        $message = "A user matching '".$whoDisplay."' was last seen on ".$timelastseen." using hostname '".$hostname."' joining the channel.";
                         break;
                 }
             }

--- a/modules/statsInfo/module.php
+++ b/modules/statsInfo/module.php
@@ -16,7 +16,7 @@ function getStatsInfo($ircdata) {
         if(mysqli_num_rows($result) == 1) {
             while($row = mysqli_fetch_assoc($result)) {
                 $id = $row['id'];
-                $nickaliases = unserialize($row['nick_aliases']);
+                $nickaliases = json_decode($row['nick_aliases'], true);
                 $totalwords = $row['total_words'];
                 $totallines = $row['total_lines'];
                 $nickcount = count($nickaliases);
@@ -41,7 +41,7 @@ function getStatsInfoTop($ircdata) {
     if(mysqli_num_rows($result) > 0) {
         $count = 1;
         while($row = mysqli_fetch_assoc($result)) {
-            $nickaliases = unserialize($row['nick_aliases']);
+            $nickaliases = json_decode($row['nick_aliases'], true);
             $UserAlias = $nickaliases[0];
             $totalwords = number_format($row['total_words']);
             $totallines = number_format($row['total_lines']);

--- a/modules/triviaSystem/module.php
+++ b/modules/triviaSystem/module.php
@@ -193,7 +193,7 @@ function triviaSystem_timeExpired($ircdata) {
 function triviaSystem_getMyScores($ircdata) {
     global $dbconnection;
 
-    $hostname = $ircdata['userhostname'];
+    $hostname = mysqli_real_escape_string($dbconnection, $ircdata['userhostname']);
     logEntry("Getting scores for hostname '".$hostname."'");
 
     $query = "SELECT userhostname,lastusednickname,scores,lastwintime FROM trivia WHERE userhostname = '".$hostname."'";
@@ -291,6 +291,8 @@ function triviaSystem_getHiScores($ircdata) {
 function triviaSystem_updateScores($hostname,$nickname,$topic) {
     global $dbconnection;
 
+    $hostname  = mysqli_real_escape_string($dbconnection, $hostname);
+    $nickname  = mysqli_real_escape_string($dbconnection, $nickname);
     $query = "SELECT userhostname,lastusednickname,scores,lastwintime FROM trivia WHERE userhostname = '".$hostname."' LIMIT 1";
     $result = mysqli_query($dbconnection,$query);
 

--- a/modules/triviaSystem/module.php
+++ b/modules/triviaSystem/module.php
@@ -205,7 +205,7 @@ function triviaSystem_getMyScores($ircdata) {
             logEntry("Found row for hostname '".$hostname."'");
             $userhostname = $row['userhostname'];
             $lastusednickname = $row['lastusednickname'];
-            $scores = unserialize($row['scores']);
+            $scores = json_decode($row['scores'], true);
             $lastwintime = $row['lastwintime'];
         }
         arsort($scores);
@@ -236,7 +236,7 @@ function triviaSystem_getHiScores($ircdata) {
         while($row = mysqli_fetch_assoc($result)) {
             $lastusednickname = $row['lastusednickname'];
             $scores = $row['scores'];
-            $scoresArray = unserialize($scores);
+            $scoresArray = json_decode($scores, true);
             if(empty($scoresArray)) {
                 $scoresArray = array();
             }
@@ -301,7 +301,7 @@ function triviaSystem_updateScores($hostname,$nickname,$topic) {
         while($row = mysqli_fetch_assoc($result)) {
             $userhostname = $row['userhostname'];
             $lastusednickname = $row['lastusednickname'];
-            $scoresArray = unserialize($row['scores']);
+            $scoresArray = json_decode($row['scores'], true);
             $lastwintime = $row['lastwintime'];
 
             //confirm hostname match
@@ -312,7 +312,7 @@ function triviaSystem_updateScores($hostname,$nickname,$topic) {
                 $newScore = ($oldScore + 1);
                 unset($scoresArray[$topic]);
                 $scoresArray[$topic] = $newScore;
-                $newScoresArray = serialize($scoresArray);
+                $newScoresArray = json_encode($scoresArray);
                 $query = "UPDATE trivia SET lastusednickname='".$newLastUsedNickname."', lastwintime='".$newLastWinTime."', scores='".$newScoresArray."' WHERE userhostname = '".$hostname."'";
             }
             $userhostname = "";
@@ -324,7 +324,7 @@ function triviaSystem_updateScores($hostname,$nickname,$topic) {
         }
     } else {
         $newScoresArray[$topic] = 1;
-        $newScoresArray = serialize($newScoresArray);
+        $newScoresArray = json_encode($newScoresArray);
         $query = "INSERT INTO trivia(userhostname,lastusednickname,scores,lastwintime) VALUES('".$hostname."','".$nickname."','".$newScoresArray."','".time()."')";
     } 
 

--- a/triggers/parseURLfromMessage/trigger.php
+++ b/triggers/parseURLfromMessage/trigger.php
@@ -91,7 +91,7 @@ function getTitle($url) {
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_USERAGENT, "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
         curl_setopt($ch, CURLOPT_TIMEOUT, 10);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
         $html = curl_exec($ch);
         curl_close($ch);
         if (!$html) { return false; }
@@ -117,7 +117,7 @@ function getRedditTitle($url) {
         CURLOPT_USERAGENT => "cIRCuitbot/1.0 by /u/mistiry",
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_TIMEOUT => 10,
-        CURLOPT_SSL_VERIFYPEER => false,
+        CURLOPT_SSL_VERIFYPEER => true,
     ]);
     $tokenResult = curl_exec($ch);
     curl_close($ch);
@@ -134,7 +134,7 @@ function getRedditTitle($url) {
         CURLOPT_HTTPHEADER => ["Authorization: Bearer " . $token],
         CURLOPT_USERAGENT => "cIRCuitbot/1.0 by /u/mistiry",
         CURLOPT_TIMEOUT => 10,
-        CURLOPT_SSL_VERIFYPEER => false,
+        CURLOPT_SSL_VERIFYPEER => true,
     ]);
     $response = curl_exec($ch);
     curl_close($ch);


### PR DESCRIPTION
## Summary

- **LIKE wildcard injection fix** (seenInfo): `%` and `_` now escaped in DB queries; minimum 2-character search enforced
- **IRC protocol injection fix**: `\r`, `\n`, `\0` stripped from user-supplied input in doActionFromCommand
- **SSL peer verification**: `CURLOPT_SSL_VERIFYPEER` enabled on all cURL calls
- **serialize → json_encode/json_decode**: Migrated all 11 callsites across statsInfo, quoteSystem, and triviaSystem — DB migration script included separately

## Notes

DB migration (`migrate_serialize_to_json.php`) must be run against any existing database before deploying this code. Verified against demoBot. DoTheNeedful migration pending.