### PR TITLE
v0.6.1 — URL parser overhaul, security fixes, CRLF fixes

### DIFF
--- a/modules/doActionFromCommand/module.php
+++ b/modules/doActionFromCommand/module.php
@@ -12,14 +12,14 @@ function doActionFromCommand($ircdata) {
         case "%COMMANDARGS%":
             if($ircdata['commandargs'] != "") {
                 $action = str_replace(["\r", "\n", "\0"], '', $ircdata['commandargs']);
-                fputs($socket, "PRIVMSG ".$ircdata['location']." :\001ACTION ".$action."\001\n");
+                fputs($socket, "PRIVMSG ".$ircdata['location']." :\001ACTION ".$action."\001\r\n");
             }
             break;
         case "%USERNICKNAME%":
-            fputs($socket, "PRIVMSG ".$ircdata['location']." :\001ACTION ".$ircdata['usernickname']."\001\n");
+            fputs($socket, "PRIVMSG ".$ircdata['location']." :\001ACTION ".$ircdata['usernickname']."\001\r\n");
             break;
         default:
-            fputs($socket, "PRIVMSG ".$ircdata['location']." :\001ACTION ".$options['action']."\001\n");
+            fputs($socket, "PRIVMSG ".$ircdata['location']." :\001ACTION ".$options['action']."\001\r\n");
     }
     return true;
 }

--- a/modules/googleGemini/module.php
+++ b/modules/googleGemini/module.php
@@ -47,26 +47,27 @@ function googleGemini_generateTextByTextPrompt($ircdata) {
         $geminiResultJson = curl_exec($curl);
         $geminiResult = json_decode($geminiResultJson, true);
 
-        $geminiResponse = trim($geminiResult["candidates"][0]["content"]["parts"][0]["text"]);
-        //$geminiResponse = str_replace("\n","  ",$geminiResponse);
+        $geminiResponse = $geminiResult["candidates"][0]["content"]["parts"][0]["text"] ?? null;
 
-        //Create random hash to save the generated results to custom HTML output
-        $outputToSave = trim($geminiResult["candidates"][0]["content"]["parts"][0]["text"]);
-
-        $savedOutput = googleGemini_saveGeneratedOutput($geminiPrompt,$outputToSave);
-
-        if(strlen($geminiResponse) > 5) {
-            $currentEpoch = time();
-            $expiryTime = $timerArray['googleGemini_timeoutExpired'];
-            $timeRemaining = $expiryTime - $currentEpoch;
-            $successText1 = stylizeText(stylizeText("Success!","color_light_green"), "bold");
-            $successText2 = stylizeText("(next run available in ".$timeRemaining."s) - check out my response at", "bold");
-            $successText3 = stylizeText(stylizeText("".$configfile['baseOutputUrl']."/view.php?gen=".$savedOutput."", "color_blue"), "bold");
-            sendPRIVMSG($ircdata['location'], "".$geminiBanner." ".$successText1." ".$successText2." ".$successText3."");
-        } else {
+        if(empty($geminiResponse) || strlen(trim($geminiResponse)) <= 5) {
+            curl_close($curl);
             $failText = stylizeText(stylizeText("Something Happened!","color_red"), "bold");
             sendPRIVMSG($ircdata['location'], "".$geminiBanner." ".$failText."");
+            return true;
         }
+
+        $geminiResponse = trim($geminiResponse);
+
+        //Create random hash to save the generated results to custom HTML output
+        $savedOutput = googleGemini_saveGeneratedOutput($geminiPrompt, $geminiResponse);
+
+        $currentEpoch = time();
+        $expiryTime = $timerArray['googleGemini_timeoutExpired'];
+        $timeRemaining = $expiryTime - $currentEpoch;
+        $successText1 = stylizeText(stylizeText("Success!","color_light_green"), "bold");
+        $successText2 = stylizeText("(next run available in ".$timeRemaining."s) - check out my response at", "bold");
+        $successText3 = stylizeText(stylizeText("".$configfile['baseOutputUrl']."/view.php?gen=".$savedOutput."", "color_blue"), "bold");
+        sendPRIVMSG($ircdata['location'], "".$geminiBanner." ".$successText1." ".$successText2." ".$successText3."");
         curl_close($curl);
         return true;
     }

--- a/modules/statsInfo/module.php
+++ b/modules/statsInfo/module.php
@@ -2,9 +2,8 @@
 function getStatsInfo($ircdata) {
     global $dbconnection;
 
-    $who = trim($ircdata['usernickname']);
-    $who = mysqli_real_escape_string($dbconnection, $who);
-    $query = "SELECT id,nick_aliases,total_words,total_lines FROM known_users WHERE hostname = '".$ircdata['userhostname']."' LIMIT 1";
+    $hostname = mysqli_real_escape_string($dbconnection, $ircdata['userhostname']);
+    $query = "SELECT id,nick_aliases,total_words,total_lines FROM known_users WHERE hostname = '".$hostname."' LIMIT 1";
 
     $result = mysqli_query($dbconnection,$query);
     $nickaliases = array();

--- a/triggers/doActionFromWord/trigger.php
+++ b/triggers/doActionFromWord/trigger.php
@@ -8,7 +8,7 @@ function doActionFromWord($ircdata) {
 
     $options = parse_ini_file("".$config['addons_dir']."/triggers/doActionFromWord/trigger.conf");
     if($options['action'] != "") {
-        fputs($socket, "PRIVMSG ".$ircdata['location']." :\001ACTION ".$options['action']."\001\n");
+        fputs($socket, "PRIVMSG ".$ircdata['location']." :\001ACTION ".$options['action']."\001\r\n");
     }
 
     return true;

--- a/triggers/doActionFromWord1in20/trigger.php
+++ b/triggers/doActionFromWord1in20/trigger.php
@@ -11,7 +11,7 @@ function doActionFromWord1in20($ircdata) {
     $rand = rand(0,19);
     if($rand == "4") {
         if($options['action'] != "") {
-            fputs($socket, "PRIVMSG ".$ircdata['location']." :\001ACTION ".$options['action']."\001\n");
+            fputs($socket, "PRIVMSG ".$ircdata['location']." :\001ACTION ".$options['action']."\001\r\n");
         }
     }
     return true;

--- a/triggers/parseURLfromMessage/trigger.php
+++ b/triggers/parseURLfromMessage/trigger.php
@@ -168,6 +168,11 @@ function getYouTubeInfo($youtubeAPIKey, $url) {
         $videoId = $m[1];
     }
 
+    // youtu.be short URLs: the path itself is the video ID (e.g. youtu.be/sCzdecygpmg)
+    if (!$videoId && preg_match('/^\/([a-zA-Z0-9_-]+)$/', $path, $m)) {
+        $videoId = $m[1];
+    }
+
     if (!$videoId) {
         return null;
     }

--- a/triggers/parseURLfromMessage/trigger.php
+++ b/triggers/parseURLfromMessage/trigger.php
@@ -539,7 +539,16 @@ function getYouTubeInfo($youtubeAPIKey, $url) {
     logEntry("YouTube Video ID from URL: ".$videoId."");
 
     $apiUrl = "https://www.googleapis.com/youtube/v3/videos?id={$videoId}&part=snippet,contentDetails&key={$youtubeAPIKey}";
-    $response = file_get_contents($apiUrl);
+    $ch = curl_init($apiUrl);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_USERAGENT => "cIRCuitbot/1.0",
+        CURLOPT_TIMEOUT => 10,
+        CURLOPT_SSL_VERIFYPEER => true,
+    ]);
+    $response = curl_exec($ch);
+    curl_close($ch);
+    if (!$response) { return null; }
     $videoData = json_decode($response, true);
 
     if (isset($videoData['items']) && count($videoData['items']) > 0) {

--- a/triggers/parseURLfromMessage/trigger.php
+++ b/triggers/parseURLfromMessage/trigger.php
@@ -96,9 +96,27 @@ function getTitle($url) {
         $html = curl_exec($ch);
         curl_close($ch);
         if (!$html) { return false; }
-        // Extract the title from the HTML
+
+        // 1. Try <title> tag
         $title = preg_match('/<title[^>]*>(.*?)<\/title>/ims', $html, $match) ? $match[1] : null;
         $title = html_entity_decode(trim((string)$title), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        // 2. Fall back to og:title (handles JS-rendered sites that set OG tags server-side)
+        if (empty($title)) {
+            if (preg_match('/<meta[^>]+property=["\']og:title["\'][^>]+content=["\']([^"\']+)["\'][^>]*>/i', $html, $match) ||
+                preg_match('/<meta[^>]+content=["\']([^"\']+)["\'][^>]+property=["\']og:title["\'][^>]*>/i', $html, $match)) {
+                $title = html_entity_decode(trim($match[1]), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            }
+        }
+
+        // 3. Fall back to twitter:title
+        if (empty($title)) {
+            if (preg_match('/<meta[^>]+name=["\']twitter:title["\'][^>]+content=["\']([^"\']+)["\'][^>]*>/i', $html, $match) ||
+                preg_match('/<meta[^>]+content=["\']([^"\']+)["\'][^>]+name=["\']twitter:title["\'][^>]*>/i', $html, $match)) {
+                $title = html_entity_decode(trim($match[1]), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            }
+        }
+
         if (empty($title)) { return false; }
         return $title;
     }

--- a/triggers/parseURLfromMessage/trigger.php
+++ b/triggers/parseURLfromMessage/trigger.php
@@ -16,6 +16,9 @@ function parseURLfromMessage($ircdata) {
     $redditclientsecret = $configfile['redditclientsecret'];
     $redditDomains = $configfile['redditDomains'];
 
+    $parsetwitter = $configfile['parsetwitter'];
+    $twitterDomains = $configfile['twitterDomains'];
+
     //First, detect if a URL was seen, then figure out if we need to send to custom parser or not
     if(stristr($ircdata['fullmessage'], "https://") || stristr($ircdata['fullmessage'], "http://")) {
         $messagePieces = explode(" ", $ircdata['fullmessage']);
@@ -55,6 +58,19 @@ function parseURLfromMessage($ircdata) {
             return true;
         }
 
+        //X / Twitter
+        if($parsetwitter == "true" && in_array($domain, $twitterDomains)) {
+            $title = getTwitterInfo($url);
+            if(!empty($title)) {
+                $urlBanner = stylizeText("-- X/Twitter --", "bold");
+                $urlBanner = stylizeText($urlBanner, "color_blue");
+                sendPRIVMSG($config['channel'], $urlBanner . " " . $title);
+            }
+            return true;
+        } elseif($parsetwitter == "false" && in_array($domain, $twitterDomains)) {
+            return true;
+        }
+
         //Default Parser
         $title = getTitle($url);
         if (!empty($title)) {
@@ -73,10 +89,10 @@ function getTitle($url) {
         $parsedUrl = parse_url($url);
         $extension = pathinfo($parsedUrl['path'], PATHINFO_EXTENSION);
         // List of disallowed file extensions
-        $disallowedExtensions = ['pdf', 'exe', 'sh', 'cmd', 'js', 'py', 'bat', 'pl', 'rb', 'ps1', 'vbs', 'msi', 'tcl'];
+        $disallowedExtensions = ['pdf', 'exe', 'sh', 'cmd', 'js', 'py', 'bat', 'pl', 'rb', 'ps1', 'vbs', 'msi', 'tcl',
+                                  'jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg', 'mp4', 'mp3', 'mov', 'avi', 'mkv', 'webm'];
         if (in_array(strtolower($extension), $disallowedExtensions)) {
-            $message = "Unable to parse URL that points to ".$extension." file.";
-            return $message;
+            return false;
         }
         // List of disallowed domains, useful if using something like the parseYoutubeURL trigger
         $disallowedDomains = ['xyoutube.com'];
@@ -93,6 +109,14 @@ function getTitle($url) {
         curl_setopt($ch, CURLOPT_USERAGENT, "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
         curl_setopt($ch, CURLOPT_TIMEOUT, 10);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($ch, CURLOPT_ENCODING, '');
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+            'Accept-Language: en-US,en;q=0.5',
+            'Connection: keep-alive',
+            'Upgrade-Insecure-Requests: 1',
+            'Cache-Control: max-age=0',
+        ]);
         $html = curl_exec($ch);
         curl_close($ch);
         if (!$html) { return false; }
@@ -120,6 +144,35 @@ function getTitle($url) {
         if (empty($title)) { return false; }
         return $title;
     }
+}
+
+function getTwitterInfo($url) {
+    $apiUrl = "https://publish.twitter.com/oembed?url=" . urlencode($url) . "&omit_script=true";
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $apiUrl);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_USERAGENT, "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+    curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+    $response = curl_exec($ch);
+    curl_close($ch);
+    if (!$response) { return null; }
+    $data = json_decode($response, true);
+    if (json_last_error() !== JSON_ERROR_NONE || empty($data['html'])) { return null; }
+
+    // Extract tweet text from the <p> inside the blockquote
+    preg_match('/<p[^>]*>(.*?)<\/p>/is', $data['html'], $m);
+    $tweetText = html_entity_decode(trim(strip_tags($m[1] ?? '')), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+    $author = $data['author_name'] ?? '';
+    if (empty($tweetText)) { return null; }
+
+    // Truncate long tweets
+    if (strlen($tweetText) > 200) {
+        $tweetText = substr($tweetText, 0, 197) . '...';
+    }
+
+    return stylizeText("@{$author}", "bold") . ": {$tweetText}";
 }
 
 function getRedditTitle($url) {

--- a/triggers/parseURLfromMessage/trigger.php
+++ b/triggers/parseURLfromMessage/trigger.php
@@ -19,6 +19,18 @@ function parseURLfromMessage($ircdata) {
     $parsetwitter = $configfile['parsetwitter'];
     $twitterDomains = $configfile['twitterDomains'];
 
+    $parsestackexchange = $configfile['parsestackexchange'];
+    $stackexchangeDomains = $configfile['stackexchangeDomains'];
+
+    $parsebluesky = $configfile['parsebluesky'];
+    $blueskyDomains = $configfile['blueskyDomains'];
+
+    $parsespotify = $configfile['parsespotify'];
+    $spotifyDomains = $configfile['spotifyDomains'];
+
+    $parsetiktok = $configfile['parsetiktok'];
+    $tiktokDomains = $configfile['tiktokDomains'];
+
     //First, detect if a URL was seen, then figure out if we need to send to custom parser or not
     if(stristr($ircdata['fullmessage'], "https://") || stristr($ircdata['fullmessage'], "http://")) {
         $messagePieces = explode(" ", $ircdata['fullmessage']);
@@ -68,6 +80,59 @@ function parseURLfromMessage($ircdata) {
             }
             return true;
         } elseif($parsetwitter == "false" && in_array($domain, $twitterDomains)) {
+            return true;
+        }
+
+        //Stack Exchange
+        $isStackExchange = in_array($domain, $stackexchangeDomains) || stristr($domain, 'stackexchange.com');
+        if($parsestackexchange == "true" && $isStackExchange) {
+            $title = getStackExchangeInfo($url);
+            if(!empty($title)) {
+                $urlBanner = stylizeText("-- Stack Exchange --", "bold");
+                $urlBanner = stylizeText($urlBanner, "color_orange");
+                sendPRIVMSG($config['channel'], $urlBanner . " " . $title);
+            }
+            return true;
+        } elseif($parsestackexchange == "false" && $isStackExchange) {
+            return true;
+        }
+
+        //Bluesky
+        if($parsebluesky == "true" && in_array($domain, $blueskyDomains)) {
+            $title = getBlueskyInfo($url);
+            if(!empty($title)) {
+                $urlBanner = stylizeText("-- Bluesky --", "bold");
+                $urlBanner = stylizeText($urlBanner, "color_light_blue");
+                sendPRIVMSG($config['channel'], $urlBanner . " " . $title);
+            }
+            return true;
+        } elseif($parsebluesky == "false" && in_array($domain, $blueskyDomains)) {
+            return true;
+        }
+
+        //Spotify
+        if($parsespotify == "true" && in_array($domain, $spotifyDomains)) {
+            $title = getSpotifyInfo($url);
+            if(!empty($title)) {
+                $urlBanner = stylizeText("-- Spotify --", "bold");
+                $urlBanner = stylizeText($urlBanner, "color_green");
+                sendPRIVMSG($config['channel'], $urlBanner . " " . $title);
+            }
+            return true;
+        } elseif($parsespotify == "false" && in_array($domain, $spotifyDomains)) {
+            return true;
+        }
+
+        //TikTok
+        if($parsetiktok == "true" && in_array($domain, $tiktokDomains)) {
+            $title = getTikTokInfo($url);
+            if(!empty($title)) {
+                $urlBanner = stylizeText("-- TikTok --", "bold");
+                $urlBanner = stylizeText($urlBanner, "color_pink");
+                sendPRIVMSG($config['channel'], $urlBanner . " " . $title);
+            }
+            return true;
+        } elseif($parsetiktok == "false" && in_array($domain, $tiktokDomains)) {
             return true;
         }
 
@@ -175,6 +240,117 @@ function getTwitterInfo($url) {
     }
 
     return stylizeText("@{$author}", "bold") . ": {$tweetText}";
+}
+
+function getStackExchangeInfo($url) {
+    $host = preg_replace('/^www\./', '', parse_url($url, PHP_URL_HOST));
+    preg_match('~/questions/(\d+)~', $url, $m);
+    $questionId = $m[1] ?? null;
+    if (!$questionId) { return null; }
+
+    if (preg_match('/^(.+?)\.stackexchange\.com$/', $host, $sm)) {
+        $site = $sm[1];
+    } else {
+        $site = preg_replace('/\.(com|net|org)$/', '', $host);
+    }
+
+    $ch = curl_init("https://api.stackexchange.com/2.3/questions/{$questionId}?site={$site}");
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_USERAGENT => "cIRCuitbot/1.0",
+        CURLOPT_TIMEOUT => 10,
+        CURLOPT_SSL_VERIFYPEER => true,
+        CURLOPT_ENCODING => '',
+    ]);
+    $response = curl_exec($ch);
+    curl_close($ch);
+    if (!$response) { return null; }
+    $data = json_decode($response, true);
+    if (json_last_error() !== JSON_ERROR_NONE || empty($data['items'][0])) { return null; }
+
+    $q       = $data['items'][0];
+    $title   = html_entity_decode($q['title'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    $score   = $q['score'] ?? 0;
+    $answers = $q['answer_count'] ?? 0;
+    $accepted = !empty($q['accepted_answer_id']) ? ' ✓' : '';
+    return stylizeText($title, "bold") . " (+" . $score . " | " . $answers . " ans" . $accepted . ")";
+}
+
+function getBlueskyInfo($url) {
+    if (!preg_match('~bsky\.app/profile/([^/]+)/post/([^/?#]+)~', $url, $m)) { return null; }
+    [, $handle, $rkey] = $m;
+
+    $ch = curl_init("https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=" . urlencode($handle));
+    curl_setopt_array($ch, [CURLOPT_RETURNTRANSFER => true, CURLOPT_USERAGENT => "cIRCuitbot/1.0",
+        CURLOPT_TIMEOUT => 10, CURLOPT_SSL_VERIFYPEER => true]);
+    $resp = curl_exec($ch);
+    curl_close($ch);
+    if (!$resp) { return null; }
+    $did = json_decode($resp, true)['did'] ?? null;
+    if (!$did) { return null; }
+
+    $atUri = "at://{$did}/app.bsky.feed.post/{$rkey}";
+    $ch = curl_init("https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread?uri=" . urlencode($atUri) . "&depth=0");
+    curl_setopt_array($ch, [CURLOPT_RETURNTRANSFER => true, CURLOPT_USERAGENT => "cIRCuitbot/1.0",
+        CURLOPT_TIMEOUT => 10, CURLOPT_SSL_VERIFYPEER => true]);
+    $resp = curl_exec($ch);
+    curl_close($ch);
+    if (!$resp) { return null; }
+    $td = json_decode($resp, true);
+    if (json_last_error() !== JSON_ERROR_NONE) { return null; }
+
+    $post   = $td['thread']['post']['record'] ?? null;
+    $author = $td['thread']['post']['author']['displayName'] ?? ($td['thread']['post']['author']['handle'] ?? '');
+    if (!$post || empty($post['text'])) { return null; }
+
+    $text = $post['text'];
+    if (strlen($text) > 200) { $text = substr($text, 0, 197) . '...'; }
+    return stylizeText("@{$author}", "bold") . ": {$text}";
+}
+
+function getSpotifyInfo($url) {
+    $ch = curl_init("https://open.spotify.com/oembed?url=" . urlencode($url));
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_USERAGENT => "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        CURLOPT_TIMEOUT => 10,
+        CURLOPT_SSL_VERIFYPEER => true,
+    ]);
+    $resp = curl_exec($ch);
+    curl_close($ch);
+    if (!$resp) { return null; }
+    $data = json_decode($resp, true);
+    if (json_last_error() !== JSON_ERROR_NONE || empty($data['title'])) { return null; }
+
+    $path = parse_url($url, PHP_URL_PATH);
+    if (stristr($path, '/track/'))         { $type = "Track"; }
+    elseif (stristr($path, '/album/'))     { $type = "Album"; }
+    elseif (stristr($path, '/playlist/'))  { $type = "Playlist"; }
+    elseif (stristr($path, '/artist/'))    { $type = "Artist"; }
+    else                                   { $type = ""; }
+
+    $label = $type ? "{$type}: " : "";
+    return $label . stylizeText($data['title'], "bold");
+}
+
+function getTikTokInfo($url) {
+    $ch = curl_init("https://www.tiktok.com/oembed?url=" . urlencode($url));
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_USERAGENT => "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        CURLOPT_TIMEOUT => 10,
+        CURLOPT_SSL_VERIFYPEER => true,
+    ]);
+    $resp = curl_exec($ch);
+    curl_close($ch);
+    if (!$resp) { return null; }
+    $data = json_decode($resp, true);
+    if (json_last_error() !== JSON_ERROR_NONE || empty($data['title'])) { return null; }
+
+    $author = $data['author_name'] ?? '';
+    $title  = $data['title'];
+    if (strlen($title) > 200) { $title = substr($title, 0, 197) . '...'; }
+    return stylizeText("@{$author}", "bold") . ": {$title}";
 }
 
 function getRedditTitle($url) {

--- a/triggers/parseURLfromMessage/trigger.php
+++ b/triggers/parseURLfromMessage/trigger.php
@@ -147,6 +147,8 @@ function getTitle($url) {
 }
 
 function getTwitterInfo($url) {
+    // Normalize to bare status URL — strip /photo/1, /mediaviewer, etc. after the status ID
+    $url = preg_replace('~(https?://(?:x|twitter)\.com/[^/?#]+/status/\d+).*$~i', '$1', $url);
     $apiUrl = "https://publish.twitter.com/oembed?url=" . urlencode($url) . "&omit_script=true";
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $apiUrl);

--- a/triggers/parseURLfromMessage/trigger.php
+++ b/triggers/parseURLfromMessage/trigger.php
@@ -57,10 +57,11 @@ function parseURLfromMessage($ircdata) {
 
         //Default Parser
         $title = getTitle($url);
-        $urlBanner = stylizeText("-- URL --", "bold");
-        $urlBanner = stylizeText($urlBanner, "color_purple");
-        $message = "".$urlBanner." ".$title."";
-        sendPRIVMSG($config['channel'], "".$message.""); 
+        if (!empty($title)) {
+            $urlBanner = stylizeText("-- URL --", "bold");
+            $urlBanner = stylizeText($urlBanner, "color_purple");
+            sendPRIVMSG($config['channel'], $urlBanner . " " . $title);
+        }
     }
     return true;
 }
@@ -97,7 +98,8 @@ function getTitle($url) {
         if (!$html) { return false; }
         // Extract the title from the HTML
         $title = preg_match('/<title[^>]*>(.*?)<\/title>/ims', $html, $match) ? $match[1] : null;
-        $title = trim($title);
+        $title = html_entity_decode(trim((string)$title), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        if (empty($title)) { return false; }
         return $title;
     }
 }

--- a/triggers/parseURLfromMessage/trigger.php
+++ b/triggers/parseURLfromMessage/trigger.php
@@ -31,6 +31,12 @@ function parseURLfromMessage($ircdata) {
     $parsetiktok = $configfile['parsetiktok'];
     $tiktokDomains = $configfile['tiktokDomains'];
 
+    $parsesteam = $configfile['parsesteam'];
+    $steamDomains = $configfile['steamDomains'];
+
+    $parsewikipedia = $configfile['parsewikipedia'];
+    $wikipediaDomains = $configfile['wikipediaDomains'];
+
     //First, detect if a URL was seen, then figure out if we need to send to custom parser or not
     if(stristr($ircdata['fullmessage'], "https://") || stristr($ircdata['fullmessage'], "http://")) {
         $messagePieces = explode(" ", $ircdata['fullmessage']);
@@ -133,6 +139,35 @@ function parseURLfromMessage($ircdata) {
             }
             return true;
         } elseif($parsetiktok == "false" && in_array($domain, $tiktokDomains)) {
+            return true;
+        }
+
+        //Steam
+        if($parsesteam == "true" && in_array($domain, $steamDomains)) {
+            $title = getSteamInfo($url);
+            if($title !== null) {
+                $urlBanner = stylizeText("-- Steam --", "bold");
+                $urlBanner = stylizeText($urlBanner, "color_teal");
+                sendPRIVMSG($config['channel'], $urlBanner . " " . $title);
+                return true;
+            }
+            // null means non-app URL (homepage, tags, etc.) — fall through to default parser
+        } elseif($parsesteam == "false" && in_array($domain, $steamDomains)) {
+            return true;
+        }
+
+        //Wikipedia
+        $isWikipedia = in_array($domain, $wikipediaDomains) || stristr($domain, 'wikipedia.org');
+        if($parsewikipedia == "true" && $isWikipedia) {
+            $title = getWikipediaInfo($url);
+            if($title !== null) {
+                $urlBanner = stylizeText("-- Wikipedia --", "bold");
+                $urlBanner = stylizeText($urlBanner, "color_light_grey");
+                sendPRIVMSG($config['channel'], $urlBanner . " " . $title);
+                return true;
+            }
+            // null means Special/Talk/User page — fall through to default parser
+        } elseif($parsewikipedia == "false" && $isWikipedia) {
             return true;
         }
 
@@ -240,6 +275,81 @@ function getTwitterInfo($url) {
     }
 
     return stylizeText("@{$author}", "bold") . ": {$tweetText}";
+}
+
+function getSteamInfo($url) {
+    preg_match('~/app/(\d+)~', $url, $m);
+    $appId = $m[1] ?? null;
+    if (!$appId) { return null; }
+
+    $ch = curl_init("https://store.steampowered.com/api/appdetails?appids={$appId}&cc=us&l=en");
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_USERAGENT => "cIRCuitbot/1.0",
+        CURLOPT_TIMEOUT => 10,
+        CURLOPT_SSL_VERIFYPEER => true,
+        CURLOPT_ENCODING => '',
+    ]);
+    $response = curl_exec($ch);
+    curl_close($ch);
+    if (!$response) { return null; }
+    $outer = json_decode($response, true);
+    if (json_last_error() !== JSON_ERROR_NONE || empty($outer[$appId]['data'])) { return null; }
+
+    $data  = $outer[$appId]['data'];
+    $name  = $data['name'] ?? null;
+    if (!$name) { return null; }
+
+    if (!empty($data['price_overview']['final_formatted'])) {
+        $price = $data['price_overview']['final_formatted'];
+    } elseif (!empty($data['is_free'])) {
+        $price = "Free to Play";
+    } else {
+        $price = null;
+    }
+
+    $meta   = $data['metacritic']['score'] ?? null;
+    $genres = !empty($data['genres']) ? implode(', ', array_slice(array_column($data['genres'], 'description'), 0, 3)) : null;
+
+    $parts = [stylizeText($name, "bold")];
+    if ($price)  { $parts[] = $price; }
+    if ($meta)   { $parts[] = "Metacritic: {$meta}"; }
+    if ($genres) { $parts[] = $genres; }
+    return implode(' | ', $parts);
+}
+
+function getWikipediaInfo($url) {
+    preg_match('~https?://([a-z]+)\.wikipedia\.org/wiki/(.+)~i', $url, $m);
+    if (empty($m[2])) { return null; }
+    $lang  = $m[1];
+    $title = $m[2];
+
+    // Strip fragment, query string from title
+    $title = preg_replace('/[?#].*$/', '', $title);
+    if (empty($title)) { return null; }
+
+    $ch = curl_init("https://{$lang}.wikipedia.org/api/rest_v1/page/summary/" . $title);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_USERAGENT => "cIRCuitbot/1.0 (https://github.com/mistiry/cIRCuitbot)",
+        CURLOPT_TIMEOUT => 10,
+        CURLOPT_SSL_VERIFYPEER => true,
+        CURLOPT_ENCODING => '',
+    ]);
+    $response = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if (!$response || $httpCode !== 200) { return null; }
+    $data = json_decode($response, true);
+    if (json_last_error() !== JSON_ERROR_NONE) { return null; }
+
+    $pageTitle   = $data['title'] ?? null;
+    $description = $data['description'] ?? null;
+    if (!$pageTitle) { return null; }
+
+    $out = stylizeText($pageTitle, "bold");
+    if (!empty($description)) { $out .= ": {$description}"; }
+    return $out;
 }
 
 function getStackExchangeInfo($url) {


### PR DESCRIPTION
## Summary
- Major expansion of the parseURLfromMessage URL parser with 6 new custom parsers
- Security fixes: SQL injection, unescaped user input, SSL verification
- Bug fixes across multiple modules

## URL Parser Changes (parseURLfromMessage)
- Added og:title and twitter:title meta tag fallbacks for JS-rendered pages
- Added youtu.be short URL video ID extraction
- Added browser-realistic headers + gzip encoding to reduce bot-blocking
- Added silent blocking for image/video/audio file extensions
- YouTube: replaced file_get_contents with cURL (proper error handling)
- **New parsers:** X/Twitter (oEmbed), Stack Exchange (API), Bluesky (AT Protocol), Spotify (oEmbed), TikTok (oEmbed), Steam (store API), Wikipedia (REST API summary)

## Security & Bug Fixes
- `statsInfo`: fixed unescaped hostname in SQL query
- `googleGemini`: fixed null dereference crash on API error response
- `doActionFromCommand`, `doActionFromWord`, `doActionFromWord1in20`: fixed \n → \r\n in all ACTION sends (IRC protocol)
- `triviaSystem`: escape hostname and nickname in SQL queries
- `seenInfo`: require 2+ char search, fix query display
- `doActionFromCommand`: strip newlines and null bytes from user input
- `channelModeration`: add perm/0 as permanent duration option
- All cURL calls: enforce SSL peer verification

## Test plan
- [ ] Post YouTube, Reddit, X/Twitter, Stack Overflow, Bluesky, Spotify, TikTok, Steam, Wikipedia links in channel
- [ ] Confirm each shows correct colored banner and title
- [ ] Confirm image/video URLs are silently ignored
- [ ] Confirm !stats works
- [ ] Confirm !gemini handles API errors gracefully
- [ ] Confirm /me-style ACTION commands display correctly in IRC