### PR TITLE
triviaSystem: strip IRC formatting codes in answer normalization

### DIFF
--- a/modules/triviaSystem/module.php
+++ b/modules/triviaSystem/module.php
@@ -178,6 +178,9 @@ function triviaSystem_checkAnswer($ircdata) {
 }
 
 function triviaSystem_normalizeAnswer($str) {
+    // Strip IRC formatting codes first — bridged Discord messages arrive with
+    // leading \x0F (reset) and may include \x03 color, \x02 bold, etc.
+    $str = preg_replace('/\x03(?:\d{1,2}(?:,\d{1,2})?)?|\x02|\x0f|\x16|\x1d|\x1f/', '', $str);
     $str = strtolower(trim($str));
     $str = preg_replace("/^(the|a|an)\s+/", "", $str);
     $str = preg_replace("/['\"\-\.,!?]/", "", $str);


### PR DESCRIPTION
Bridged Discord users' messages arrive with a leading \x0F (reset formatting) byte that survives bot.php's bridge processing. That byte made every Discord trivia answer match as fuzzy at best (one byte off from the primary) and rejected entirely for short (<6 char) answers.

Fix is in normalizeAnswer so both input and stored answers go through the same strip, keeping comparison logic centralized.