### PR TITLE
triviaSystem: link to per-player profile, not just leaderboard

### DIFF
--- a/modules/triviaSystem/module.conf.example
+++ b/modules/triviaSystem/module.conf.example
@@ -27,8 +27,13 @@ hintStrength = "medium"
 ; Uses an in-memory window — resets if the bot restarts, which is acceptable for short windows
 noRepeatWindow = "60"
 
-; statsURL: if set, this URL is appended to the win message and shown in !triviastats output
-; Leave empty to disable
+; statsURL: base URL of the trivia website section (where player.php lives).
+; If set, the bot appends a player profile link to win announcements (winner's profile)
+; and to !triviastats output (the looked-up user's profile). The bot appends
+; "player.php?id=<known_user_id>" automatically, falling back to
+; "player.php?h=<hostname>" when there's no known_user record.
+; Example: statsURL = "https://dotheneedful.online/trivia/"
+; Leave empty to disable.
 statsURL = ""
 
 ; List of topics available for the bot to choose from

--- a/modules/triviaSystem/module.php
+++ b/modules/triviaSystem/module.php
@@ -262,7 +262,10 @@ function triviaSystem_processWin($ircdata, $isFuzzy, $matchedAnswer = null) {
     }
 
     if(!empty($configfile['statsURL'])) {
-        sendPRIVMSG($ircdata['location'], "{$prefix} " . stylizeText("Full leaderboard: " . $configfile['statsURL'], "bold"));
+        $profileURL = triviaSystem_buildProfileURL($configfile['statsURL'], $ircdata['userhostname']);
+        if(!empty($profileURL)) {
+            sendPRIVMSG($ircdata['location'], "{$prefix} " . stylizeText("Trivia profile: " . $profileURL, "bold"));
+        }
     }
 
     triviaSystem_cleanup($activityName);
@@ -721,14 +724,25 @@ function triviaSystem_getStats($ircdata) {
 
     sendPRIVMSG($ircdata['location'], $statsLine);
 
-    if(!empty($config['statsURL'] ?? '') || !empty(parse_ini_file("{$config['addons_dir']}/modules/triviaSystem/module.conf")['statsURL'])) {
-        $confFile = parse_ini_file("{$config['addons_dir']}/modules/triviaSystem/module.conf");
-        if(!empty($confFile['statsURL'])) {
-            sendPRIVMSG($ircdata['location'], "{$prefix} Full stats: " . $confFile['statsURL']);
+    $confFile = parse_ini_file("{$config['addons_dir']}/modules/triviaSystem/module.conf");
+    if(!empty($confFile['statsURL'])) {
+        $profileURL = triviaSystem_buildProfileURL($confFile['statsURL'], $hostname);
+        if(!empty($profileURL)) {
+            sendPRIVMSG($ircdata['location'], "{$prefix} Profile: " . $profileURL);
         }
     }
 
     return true;
+}
+
+function triviaSystem_buildProfileURL($baseURL, $hostname) {
+    if(empty($baseURL)) return '';
+    $base = rtrim($baseURL, '/') . '/';
+    $userRecord = function_exists('getUserRecord') ? getUserRecord($hostname) : null;
+    if($userRecord && !empty($userRecord['id'])) {
+        return $base . 'player.php?id=' . (int)$userRecord['id'];
+    }
+    return $base . 'player.php?h=' . urlencode($hostname);
 }
 
 function triviaSystem_visibleLength($str) {


### PR DESCRIPTION
statsURL is now treated as a base URL (e.g. https://example.com/trivia/). The bot appends "player.php?id=<known_user_id>" to win announcements (winner's own profile) and !triviastats output (looked-up user's profile). Falls back to "player.php?h=<hostname>" when the user has no known_users record. Helper added: triviaSystem_buildProfileURL().

Updated module.conf.example to document the new behavior.