### PR TITLE
Replace customer-specific URLs in conf examples with placeholders

### DIFF
--- a/modules/googleGemini/module.conf.example
+++ b/modules/googleGemini/module.conf.example
@@ -1,5 +1,5 @@
 activityName = "googleGemini"
 geminiAPIkey = "APIKEYHERE"
-baseOutputUrl = "https://dotheneedful.online/gemini"
+baseOutputUrl = "https://your-website.example/gemini"
 timeBetweenRequests = "300" ;number of seconds between allowing new requests to the Gemini API
 module[] = "gemini||googleGemini_generateTextByTextPrompt"

--- a/modules/triviaSystem/module.conf.example
+++ b/modules/triviaSystem/module.conf.example
@@ -32,7 +32,7 @@ noRepeatWindow = "60"
 ; and to !triviastats output (the looked-up user's profile). The bot appends
 ; "player.php?id=<known_user_id>" automatically, falling back to
 ; "player.php?h=<hostname>" when there's no known_user record.
-; Example: statsURL = "https://dotheneedful.online/trivia/"
+; Example: statsURL = "https://your-website.example/trivia/"
 ; Leave empty to disable.
 statsURL = ""
 


### PR DESCRIPTION
Two example config files referenced a specific deployment's domain (dotheneedful.online) — that domain belongs to one installation of the bot, not the upstream project. Anyone cloning the repo would have inherited that URL as a default, which is incorrect and misleading.

Replaced both with the generic "your-website.example" placeholder so operators understand they need to substitute their own host.

- modules/triviaSystem/module.conf.example: statsURL example
- modules/googleGemini/module.conf.example: baseOutputUrl default